### PR TITLE
Release v0.2 & update to Mio v0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+* Updated to Mio v0.8.
+
 ## v0.1.5
 
 * Add `Signal::User1` (`SIGUSR1`) and `Signal::User2` (`SIGUSR2`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "mio-signals"
 description   = "Crate for handling signals with Mio."
-version       = "0.1.5"
+version       = "0.2.0"
 authors       = ["Thomas de Zeeuw <thomasdezeeuw@gmail.com>"]
 license       = "MIT"
 documentation = "https://docs.rs/mio-signals"
@@ -18,7 +18,7 @@ travis-ci = { repository = "Thomasdezeeuw/mio-signals", branch = "master" }
 libc = "0.2.80"
 log  = "0.4.11"
 # Need `SourceFd` from `os-util`.
-mio  = { version = "0.7.6", features = ["os-ext"] }
+mio  = { version = "0.8.0", features = ["os-ext"] }
 
 [[test]]
 name    = "multi_threaded"


### PR DESCRIPTION
Mio v0.8 contains no breaking changes for us. However to ensure people
using Mio v0.7 don't get Mio twice I'm considering it a breaking change,
hence the update of the major (pre v1) version.